### PR TITLE
Remove duplicate declaration and fix import error

### DIFF
--- a/packages/nlcst-types/src/type-guard.ts
+++ b/packages/nlcst-types/src/type-guard.ts
@@ -1,5 +1,6 @@
 // MIT © 2017 azu
 import { Paragraph, Punctuation, Root, Sentence, Source, TextNode, WhiteSpace, Word } from "./nlcst-types";
+import { Text } from "unist-types";
 
 export const isRoot = (v: any): v is Root => {
     return v && v.type === "RootNode";

--- a/packages/unist-types/src/unist-types.ts
+++ b/packages/unist-types/src/unist-types.ts
@@ -35,7 +35,3 @@ export interface Text extends Node {
 export interface Parent extends Node {
     children: Array<Node | Parent>;
 }
-
-export interface Text extends Node {
-    value: string;
-}


### PR DESCRIPTION
Hey there,

This is causing a build error for me with projects that use nlcst-types as a dependency, it seems that the `Text` type is referenced without being imported in type-guards.

While I was checking where it came from I noticed it had been accidentally defined twice in the source location