### PR TITLE
feat: pass config down to kuromojin

### DIFF
--- a/packages/nlcst-parse-japanese/src/nlcst-parse-japanese.ts
+++ b/packages/nlcst-parse-japanese/src/nlcst-parse-japanese.ts
@@ -319,7 +319,7 @@ export class JapaneseParser {
     private tokenizer!: { tokenize(text: string): any };
     private dicPath?: string;
 
-    constructor(options: { dicPath?: string }) {
+    constructor(options: { dicPath?: string } = {}) {
         this.dicPath = options.dicPath;
     }
 

--- a/packages/nlcst-parse-japanese/src/nlcst-parse-japanese.ts
+++ b/packages/nlcst-parse-japanese/src/nlcst-parse-japanese.ts
@@ -317,7 +317,7 @@ function tokenize(
  */
 export class JapaneseParser {
     private tokenizer!: { tokenize(text: string): any };
-    protected dicPath?: string;
+    private dicPath?: string;
 
     constructor(options: { dicPath?: string }) {
         this.dicPath = options.dicPath;

--- a/packages/nlcst-parse-japanese/src/nlcst-parse-japanese.ts
+++ b/packages/nlcst-parse-japanese/src/nlcst-parse-japanese.ts
@@ -317,9 +317,15 @@ function tokenize(
  */
 export class JapaneseParser {
     private tokenizer!: { tokenize(text: string): any };
+    protected dicPath?: string;
 
-    ready() {
-        return getTokenizer().then((tokenizer: any) => {
+    constructor(options: { dicPath?: string }) {
+        this.dicPath = options.dicPath;
+    }
+
+    public ready() {
+        const options = this.dicPath && { dicPath: this.dicPath };
+        return getTokenizer(options).then((tokenizer: any) => {
             this.tokenizer = tokenizer;
         });
     }


### PR DESCRIPTION
https://github.com/azu/nlp-pattern-match/issues/5

Pass undefined to https://github.com/azu/kuromojin/blob/master/src/kuromojin.js#L25 if no option is passed in.